### PR TITLE
Classes renaming according to README.md

### DIFF
--- a/app/src/main/java/com/bgauthey/speedotracker/service/LocationProvider.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/service/LocationProvider.java
@@ -9,60 +9,62 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * <p>
  * It provides methods to notify about {@link LocationProvider} states.
  * <p>
- * {@link OnLocationServiceStateChangedListener} gives feedback about speed recording state.
+ * {@link OnSpeedRecordingStateChangedListener} gives feedback about speed recording state.
  * <p>
- * {@link OnLocationServiceSpeedChangedListener} gives feedback about speed changed.
+ * {@link OnSpeedChangedListener} gives feedback about speed changed.
+ * <p>
+ * {@link OnAverageSpeedChangedListener} gives feedback about average speed changed.
  */
 public abstract class LocationProvider {
 
     /**
      * Interface definition for a callback to be invoked when speed recording state changed.
      */
-    public interface OnLocationServiceStateChangedListener {
+    public interface OnSpeedRecordingStateChangedListener {
         /**
          * Invoked when speed recording state changed.
          *
          * @param enabled true if under recording, false otherwise
          */
-        void onLocationServiceStateChangedListener(boolean enabled);
+        void onSpeedRecordingStateChanged(boolean enabled);
     }
 
     /**
      * Interface definition for a callback to be invoked when speed changed.
      */
-    public interface OnLocationServiceSpeedChangedListener {
+    public interface OnSpeedChangedListener {
         /**
          * Invoked when the location is updated.
          *
          * @param speed    speed computed for this location
-         * @param location
+         * @param location location where speed is computed
          */
-        void onLocationServiceSpeedChangedListener(float speed, Location location);
+        void onSpeedChanged(float speed, Location location);
 
         /**
          * Invoked when speed activity changed. Speed is considered active when greater than 0 and inactive when equal to 0.
          *
          * @param active true if speed is active, false otherwise.
          */
-        void onLocationServiceSpeedActivityChangedListener(boolean active);
+        void onSpeedActivityChanged(boolean active);
     }
 
     /**
-     * Interface definition for a callback to be invoked when speed changed.
+     * Interface definition for a callback to be invoked when average speed changed.
      */
-    public interface OnLocationServiceAverageSpeedChangedListener {
+    public interface OnAverageSpeedChangedListener {
         /**
          * Invoked when the average speed is updated.
          *
-         * @param averageSpeed    average speed for the section.
+         * @param averageSpeed average speed for the section.
          */
-        void onLocationServiceAverageSpeedChangedListener(float averageSpeed, float distance, int timeElapsed);
+        void onAverageSpeedChanged(float averageSpeed, float distance, int timeElapsed);
 
     }
 
-    private CopyOnWriteArrayList<OnLocationServiceStateChangedListener> mOnLocationServiceStateChangedListeners = new CopyOnWriteArrayList<>();
-    private CopyOnWriteArrayList<OnLocationServiceSpeedChangedListener> mOnLocationServiceSpeedChangedListeners = new CopyOnWriteArrayList<>();
-    private CopyOnWriteArrayList<OnLocationServiceAverageSpeedChangedListener> mOnLocationServiceAverageSpeedChangedListeners = new CopyOnWriteArrayList<>();
+    private CopyOnWriteArrayList<OnSpeedRecordingStateChangedListener> mOnSpeedRecordingStateChangedListeners = new CopyOnWriteArrayList<>();
+    private CopyOnWriteArrayList<OnSpeedChangedListener> mOnSpeedChangedListeners = new CopyOnWriteArrayList<>();
+    private CopyOnWriteArrayList<OnAverageSpeedChangedListener> mOnAverageSpeedChangedListeners = new CopyOnWriteArrayList<>();
 
     /**
      * Get the tracking state to know if {@link LocationProvider} is ready to start recording speed.
@@ -112,116 +114,116 @@ public abstract class LocationProvider {
     }
 
     /**
-     * Register a {@link OnLocationServiceStateChangedListener}.
+     * Register a {@link OnSpeedRecordingStateChangedListener}.
      * <p>
      * Don't forget to unregister listener when client as finished to deal with it to avoid leak.
      *
      * @param locationServiceStateChangedListener the listener to register
-     * @see #unregisterOnLocationServiceStateChangedListener(OnLocationServiceStateChangedListener)
+     * @see #unregisterOnLocationServiceStateChangedListener(OnSpeedRecordingStateChangedListener)
      */
-    public final void registerOnLocationServiceStateChangedListener(OnLocationServiceStateChangedListener locationServiceStateChangedListener) {
-        if (mOnLocationServiceStateChangedListeners.contains(locationServiceStateChangedListener)) {
+    public final void registerOnLocationServiceStateChangedListener(OnSpeedRecordingStateChangedListener locationServiceStateChangedListener) {
+        if (mOnSpeedRecordingStateChangedListeners.contains(locationServiceStateChangedListener)) {
             return;
         }
-        mOnLocationServiceStateChangedListeners.add(locationServiceStateChangedListener);
+        mOnSpeedRecordingStateChangedListeners.add(locationServiceStateChangedListener);
     }
 
     /**
-     * Unregister a {@link OnLocationServiceStateChangedListener}.
+     * Unregister a {@link OnSpeedRecordingStateChangedListener}.
      *
      * @param locationServiceStateChangedListener the listener to unregister
      */
-    public final void unregisterOnLocationServiceStateChangedListener(OnLocationServiceStateChangedListener locationServiceStateChangedListener) {
-        if (mOnLocationServiceStateChangedListeners.contains(locationServiceStateChangedListener)) {
-            mOnLocationServiceStateChangedListeners.remove(locationServiceStateChangedListener);
+    public final void unregisterOnLocationServiceStateChangedListener(OnSpeedRecordingStateChangedListener locationServiceStateChangedListener) {
+        if (mOnSpeedRecordingStateChangedListeners.contains(locationServiceStateChangedListener)) {
+            mOnSpeedRecordingStateChangedListeners.remove(locationServiceStateChangedListener);
         }
     }
 
     /**
-     * Register a {@link OnLocationServiceSpeedChangedListener}.
+     * Register a {@link OnSpeedChangedListener}.
      * <p>
      * Don't forget to unregister listener when client as finished to deal with it to avoid leak.
      *
-     * @param onLocationServiceSpeedChangedListener the listener to register
-     * @see #unregisterOnLocationServiceSpeedChangedListener(OnLocationServiceSpeedChangedListener)
+     * @param onSpeedChangedListener the listener to register
+     * @see #unregisterOnLocationServiceSpeedChangedListener(OnSpeedChangedListener)
      */
-    public final void registerOnLocationServiceSpeedChangedListener(OnLocationServiceSpeedChangedListener onLocationServiceSpeedChangedListener) {
-        if (mOnLocationServiceSpeedChangedListeners.contains(onLocationServiceSpeedChangedListener)) {
+    public final void registerOnLocationServiceSpeedChangedListener(OnSpeedChangedListener onSpeedChangedListener) {
+        if (mOnSpeedChangedListeners.contains(onSpeedChangedListener)) {
             return;
         }
-        mOnLocationServiceSpeedChangedListeners.add(onLocationServiceSpeedChangedListener);
+        mOnSpeedChangedListeners.add(onSpeedChangedListener);
     }
 
     /**
-     * Unregister a {@link OnLocationServiceSpeedChangedListener}.
+     * Unregister a {@link OnSpeedChangedListener}.
      *
      * @param locationServiceSpeedChangedListener the listener to unregister
      */
-    public final void unregisterOnLocationServiceSpeedChangedListener(OnLocationServiceSpeedChangedListener locationServiceSpeedChangedListener) {
-        if (mOnLocationServiceSpeedChangedListeners.contains(locationServiceSpeedChangedListener)) {
-            mOnLocationServiceSpeedChangedListeners.remove(locationServiceSpeedChangedListener);
+    public final void unregisterOnLocationServiceSpeedChangedListener(OnSpeedChangedListener locationServiceSpeedChangedListener) {
+        if (mOnSpeedChangedListeners.contains(locationServiceSpeedChangedListener)) {
+            mOnSpeedChangedListeners.remove(locationServiceSpeedChangedListener);
         }
     }
 
     /**
-     * Register a {@link OnLocationServiceAverageSpeedChangedListener}.
+     * Register a {@link OnAverageSpeedChangedListener}.
      * <p>
      * Don't forget to unregister listener when client as finished to deal with it to avoid leak.
      *
-     * @param onLocationServiceAverageSpeedChangedListener the listener to register
-     * @see #unregisterOnLocationServiceAverageSpeedChangedListener(OnLocationServiceAverageSpeedChangedListener)
+     * @param onAverageSpeedChangedListener the listener to register
+     * @see #unregisterOnLocationServiceAverageSpeedChangedListener(OnAverageSpeedChangedListener)
      */
-    public final void registerOnLocationServiceAverageSpeedChangedListener(OnLocationServiceAverageSpeedChangedListener onLocationServiceAverageSpeedChangedListener) {
-        if (mOnLocationServiceAverageSpeedChangedListeners.contains(onLocationServiceAverageSpeedChangedListener)) {
+    public final void registerOnLocationServiceAverageSpeedChangedListener(OnAverageSpeedChangedListener onAverageSpeedChangedListener) {
+        if (mOnAverageSpeedChangedListeners.contains(onAverageSpeedChangedListener)) {
             return;
         }
-        mOnLocationServiceAverageSpeedChangedListeners.add(onLocationServiceAverageSpeedChangedListener);
+        mOnAverageSpeedChangedListeners.add(onAverageSpeedChangedListener);
     }
 
     /**
-     * Unregister a {@link OnLocationServiceAverageSpeedChangedListener}.
+     * Unregister a {@link OnAverageSpeedChangedListener}.
      *
      * @param locationServiceAverageSpeedChangedListener the listener to unregister
      */
-    public final void unregisterOnLocationServiceAverageSpeedChangedListener(OnLocationServiceAverageSpeedChangedListener locationServiceAverageSpeedChangedListener) {
-        if (mOnLocationServiceAverageSpeedChangedListeners.contains(locationServiceAverageSpeedChangedListener)) {
-            mOnLocationServiceAverageSpeedChangedListeners.remove(locationServiceAverageSpeedChangedListener);
+    public final void unregisterOnLocationServiceAverageSpeedChangedListener(OnAverageSpeedChangedListener locationServiceAverageSpeedChangedListener) {
+        if (mOnAverageSpeedChangedListeners.contains(locationServiceAverageSpeedChangedListener)) {
+            mOnAverageSpeedChangedListeners.remove(locationServiceAverageSpeedChangedListener);
         }
     }
 
     /**
-     * Call it to invoke {@link OnLocationServiceStateChangedListener#onLocationServiceStateChangedListener(boolean)} on all registered listeners.
+     * Call it to invoke {@link OnSpeedRecordingStateChangedListener#onSpeedRecordingStateChanged(boolean)} on all registered listeners.
      */
     protected void notifyOnStateChanged(boolean enabled) {
-        for (OnLocationServiceStateChangedListener onLocationServiceStateChangedListener : mOnLocationServiceStateChangedListeners) {
-            onLocationServiceStateChangedListener.onLocationServiceStateChangedListener(enabled);
+        for (OnSpeedRecordingStateChangedListener onSpeedRecordingStateChangedListener : mOnSpeedRecordingStateChangedListeners) {
+            onSpeedRecordingStateChangedListener.onSpeedRecordingStateChanged(enabled);
         }
     }
 
     /**
-     * Call it to invoke {@link OnLocationServiceSpeedChangedListener#onLocationServiceSpeedChangedListener(float, Location)} on all registered listeners.
+     * Call it to invoke {@link OnSpeedChangedListener#onSpeedChanged(float, Location)} on all registered listeners.
      */
     protected void notifyOnSpeedChanged(float speed, Location location) {
-        for (OnLocationServiceSpeedChangedListener onLocationServiceSpeedChangedListener : mOnLocationServiceSpeedChangedListeners) {
-            onLocationServiceSpeedChangedListener.onLocationServiceSpeedChangedListener(speed, location);
+        for (OnSpeedChangedListener onSpeedChangedListener : mOnSpeedChangedListeners) {
+            onSpeedChangedListener.onSpeedChanged(speed, location);
         }
     }
 
     /**
-     * Call it to invoke {@link OnLocationServiceSpeedChangedListener#onLocationServiceSpeedActivityChangedListener(boolean)} on all registered listeners.
+     * Call it to invoke {@link OnSpeedChangedListener#onSpeedActivityChanged(boolean)} on all registered listeners.
      */
     protected void notifyOnSpeedActivityChanged(boolean active) {
-        for (OnLocationServiceSpeedChangedListener onLocationServiceSpeedChangedListener : mOnLocationServiceSpeedChangedListeners) {
-            onLocationServiceSpeedChangedListener.onLocationServiceSpeedActivityChangedListener(active);
+        for (OnSpeedChangedListener onSpeedChangedListener : mOnSpeedChangedListeners) {
+            onSpeedChangedListener.onSpeedActivityChanged(active);
         }
     }
 
     /**
-     * Call it to invoke {@link OnLocationServiceAverageSpeedChangedListener#onLocationServiceAverageSpeedChangedListener(float, float, int)} on all registered listeners.
+     * Call it to invoke {@link OnAverageSpeedChangedListener#onAverageSpeedChanged(float, float, int)} on all registered listeners.
      */
     protected void notifyOnAverageSpeedChanged(float averageSpeed, float distance, int timeElapsed) {
-        for (OnLocationServiceAverageSpeedChangedListener onLocationServiceAverageSpeedChangedListener : mOnLocationServiceAverageSpeedChangedListeners) {
-            onLocationServiceAverageSpeedChangedListener.onLocationServiceAverageSpeedChangedListener(averageSpeed, distance, timeElapsed);
+        for (OnAverageSpeedChangedListener onAverageSpeedChangedListener : mOnAverageSpeedChangedListeners) {
+            onAverageSpeedChangedListener.onAverageSpeedChanged(averageSpeed, distance, timeElapsed);
         }
     }
 }

--- a/app/src/main/java/com/bgauthey/speedotracker/service/LocationProvider.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/service/LocationProvider.java
@@ -7,13 +7,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 /**
  * A base to create a provider handling location and speed.
  * <p>
- * It provides methods to notify about {@link LocationService} states.
+ * It provides methods to notify about {@link LocationProvider} states.
  * <p>
  * {@link OnLocationServiceStateChangedListener} gives feedback about speed recording state.
  * <p>
  * {@link OnLocationServiceSpeedChangedListener} gives feedback about speed changed.
  */
-public abstract class LocationService {
+public abstract class LocationProvider {
 
     /**
      * Interface definition for a callback to be invoked when speed recording state changed.
@@ -65,26 +65,26 @@ public abstract class LocationService {
     private CopyOnWriteArrayList<OnLocationServiceAverageSpeedChangedListener> mOnLocationServiceAverageSpeedChangedListeners = new CopyOnWriteArrayList<>();
 
     /**
-     * Get the tracking state to know if {@link LocationService} is ready to start recording speed.
+     * Get the tracking state to know if {@link LocationProvider} is ready to start recording speed.
      *
      * @return true if ready, false otherwise
      */
     public abstract boolean isTrackingReady();
 
     /**
-     * Get the tracking running state to know if {@link LocationService} is recording speed.
+     * Get the tracking running state to know if {@link LocationProvider} is recording speed.
      *
      * @return true if tracking started, false otherwise
      */
     public abstract boolean isTrackingRunning();
 
     /**
-     * Request {@link LocationService} to start recording speed.
+     * Request {@link LocationProvider} to start recording speed.
      */
     public abstract void startTracking();
 
     /**
-     * Request {@link LocationService} to stop recording speed.
+     * Request {@link LocationProvider} to stop recording speed.
      */
     public abstract void stopTracking();
 

--- a/app/src/main/java/com/bgauthey/speedotracker/service/gps/GpsLocationProvider.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/service/gps/GpsLocationProvider.java
@@ -2,20 +2,19 @@ package com.bgauthey.speedotracker.service.gps;
 
 import android.location.Location;
 import android.location.LocationListener;
-import android.location.LocationProvider;
 import android.os.Bundle;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
 import com.bgauthey.speedotracker.Constants;
-import com.bgauthey.speedotracker.service.LocationService;
+import com.bgauthey.speedotracker.service.LocationProvider;
 
 import java.util.concurrent.TimeUnit;
 
 /**
- * Provides a {@link LocationService} that uses GPS to get location and speed.
+ * Provides a {@link LocationProvider} that uses GPS to get location and speed.
  */
-public class GpsLocationProvider extends LocationService implements LocationListener {
+public class GpsLocationProvider extends LocationProvider implements LocationListener {
 
     private static final String TAG = GpsLocationProvider.class.getSimpleName();
 
@@ -122,7 +121,7 @@ public class GpsLocationProvider extends LocationService implements LocationList
     // Interface implementation
     ///////////////////////////////////////////////////////////////////////////
 
-    //region LocationService
+    //region LocationProvider
     @Override
     public boolean isTrackingReady() {
         return mLocationCallback.isTrackingReady();
@@ -203,7 +202,7 @@ public class GpsLocationProvider extends LocationService implements LocationList
     public void onStatusChanged(String provider, int status, Bundle extras) {
         Log.d(TAG, "onStatusChanged: " + provider + ", status = " + status);
         switch (status) {
-            case LocationProvider.AVAILABLE:
+            case android.location.LocationProvider.AVAILABLE:
                 updateTrackingState(true);
                 break;
             default:

--- a/app/src/main/java/com/bgauthey/speedotracker/speedtracking/SpeedTrackingPresenter.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/speedtracking/SpeedTrackingPresenter.java
@@ -47,12 +47,12 @@ public class SpeedTrackingPresenter implements SpeedTrackingContract.Presenter {
 
     void registerListeners() {
         mLocationProvider.registerOnLocationServiceStateChangedListener(mLocationServiceStateChangedListener);
-        mLocationProvider.registerOnLocationServiceSpeedChangedListener(mOnLocationServiceSpeedChangedListener);
+        mLocationProvider.registerOnLocationServiceSpeedChangedListener(mOnSpeedChangedListener);
     }
 
     void unregisterListeners() {
         mLocationProvider.unregisterOnLocationServiceStateChangedListener(mLocationServiceStateChangedListener);
-        mLocationProvider.unregisterOnLocationServiceSpeedChangedListener(mOnLocationServiceSpeedChangedListener);
+        mLocationProvider.unregisterOnLocationServiceSpeedChangedListener(mOnSpeedChangedListener);
     }
 
     private void showInstantSpeedScreen(boolean show) {
@@ -67,25 +67,25 @@ public class SpeedTrackingPresenter implements SpeedTrackingContract.Presenter {
         }
     }
 
-    private final LocationProvider.OnLocationServiceStateChangedListener mLocationServiceStateChangedListener
-            = new LocationProvider.OnLocationServiceStateChangedListener() {
+    private final LocationProvider.OnSpeedRecordingStateChangedListener mLocationServiceStateChangedListener
+            = new LocationProvider.OnSpeedRecordingStateChangedListener() {
         @Override
-        public void onLocationServiceStateChangedListener(boolean enabled) {
+        public void onSpeedRecordingStateChanged(boolean enabled) {
             showInstantSpeedScreen(enabled);
             mView.updateButtonState(!enabled);
         }
     };
 
-    private final LocationProvider.OnLocationServiceSpeedChangedListener mOnLocationServiceSpeedChangedListener
-            = new LocationProvider.OnLocationServiceSpeedChangedListener() {
+    private final LocationProvider.OnSpeedChangedListener mOnSpeedChangedListener
+            = new LocationProvider.OnSpeedChangedListener() {
 
         @Override
-        public void onLocationServiceSpeedActivityChangedListener(boolean active) {
+        public void onSpeedActivityChanged(boolean active) {
             showInstantSpeedScreen(active);
         }
 
         @Override
-        public void onLocationServiceSpeedChangedListener(float speed, Location location) {
+        public void onSpeedChanged(float speed, Location location) {
             // Nothing to do
         }
     };

--- a/app/src/main/java/com/bgauthey/speedotracker/speedtracking/SpeedTrackingPresenter.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/speedtracking/SpeedTrackingPresenter.java
@@ -2,7 +2,7 @@ package com.bgauthey.speedotracker.speedtracking;
 
 import android.location.Location;
 
-import com.bgauthey.speedotracker.service.LocationService;
+import com.bgauthey.speedotracker.service.LocationProvider;
 
 /**
  * Listens to user actions from the UI {@link SpeedTrackingActivity}, retrieves the data and updates
@@ -11,17 +11,17 @@ import com.bgauthey.speedotracker.service.LocationService;
 public class SpeedTrackingPresenter implements SpeedTrackingContract.Presenter {
 
     private SpeedTrackingContract.View mView;
-    private LocationService mLocationService;
+    private LocationProvider mLocationProvider;
 
-    public SpeedTrackingPresenter(SpeedTrackingContract.View view, LocationService locationService) {
+    public SpeedTrackingPresenter(SpeedTrackingContract.View view, LocationProvider locationProvider) {
         mView = view;
-        mLocationService = locationService;
+        mLocationProvider = locationProvider;
     }
 
     @Override
     public void start() {
         registerListeners();
-        showInstantSpeedScreen(mLocationService.isSpeedActive());
+        showInstantSpeedScreen(mLocationProvider.isSpeedActive());
     }
 
     @Override
@@ -31,28 +31,28 @@ public class SpeedTrackingPresenter implements SpeedTrackingContract.Presenter {
 
     @Override
     public void toggleTracking() {
-        if (!mLocationService.isTrackingReady()) {
+        if (!mLocationProvider.isTrackingReady()) {
             mView.showTrackingNotReady();
-        } else if (!mLocationService.isTrackingRunning()) {
-            mLocationService.startTracking();
+        } else if (!mLocationProvider.isTrackingRunning()) {
+            mLocationProvider.startTracking();
         } else {
-            mLocationService.stopTracking();
+            mLocationProvider.stopTracking();
         }
     }
 
     @Override
     public void startTracking() {
-        mLocationService.startTracking();
+        mLocationProvider.startTracking();
     }
 
     void registerListeners() {
-        mLocationService.registerOnLocationServiceStateChangedListener(mLocationServiceStateChangedListener);
-        mLocationService.registerOnLocationServiceSpeedChangedListener(mOnLocationServiceSpeedChangedListener);
+        mLocationProvider.registerOnLocationServiceStateChangedListener(mLocationServiceStateChangedListener);
+        mLocationProvider.registerOnLocationServiceSpeedChangedListener(mOnLocationServiceSpeedChangedListener);
     }
 
     void unregisterListeners() {
-        mLocationService.unregisterOnLocationServiceStateChangedListener(mLocationServiceStateChangedListener);
-        mLocationService.unregisterOnLocationServiceSpeedChangedListener(mOnLocationServiceSpeedChangedListener);
+        mLocationProvider.unregisterOnLocationServiceStateChangedListener(mLocationServiceStateChangedListener);
+        mLocationProvider.unregisterOnLocationServiceSpeedChangedListener(mOnLocationServiceSpeedChangedListener);
     }
 
     private void showInstantSpeedScreen(boolean show) {
@@ -67,8 +67,8 @@ public class SpeedTrackingPresenter implements SpeedTrackingContract.Presenter {
         }
     }
 
-    private final LocationService.OnLocationServiceStateChangedListener mLocationServiceStateChangedListener
-            = new LocationService.OnLocationServiceStateChangedListener() {
+    private final LocationProvider.OnLocationServiceStateChangedListener mLocationServiceStateChangedListener
+            = new LocationProvider.OnLocationServiceStateChangedListener() {
         @Override
         public void onLocationServiceStateChangedListener(boolean enabled) {
             showInstantSpeedScreen(enabled);
@@ -76,8 +76,8 @@ public class SpeedTrackingPresenter implements SpeedTrackingContract.Presenter {
         }
     };
 
-    private final LocationService.OnLocationServiceSpeedChangedListener mOnLocationServiceSpeedChangedListener
-            = new LocationService.OnLocationServiceSpeedChangedListener() {
+    private final LocationProvider.OnLocationServiceSpeedChangedListener mOnLocationServiceSpeedChangedListener
+            = new LocationProvider.OnLocationServiceSpeedChangedListener() {
 
         @Override
         public void onLocationServiceSpeedActivityChangedListener(boolean active) {

--- a/app/src/main/java/com/bgauthey/speedotracker/speedtracking/feedback/FeedbackPresenter.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/speedtracking/feedback/FeedbackPresenter.java
@@ -50,10 +50,10 @@ public class FeedbackPresenter implements FeedbackContract.Presenter {
     // Final implementation
     ///////////////////////////////////////////////////////////////////////////
 
-    private final LocationProvider.OnLocationServiceAverageSpeedChangedListener mAverageSpeedChangedListener =
-            new LocationProvider.OnLocationServiceAverageSpeedChangedListener() {
+    private final LocationProvider.OnAverageSpeedChangedListener mAverageSpeedChangedListener =
+            new LocationProvider.OnAverageSpeedChangedListener() {
                 @Override
-                public void onLocationServiceAverageSpeedChangedListener(float averageSpeed, float distance, int timeElapsed) {
+                public void onAverageSpeedChanged(float averageSpeed, float distance, int timeElapsed) {
                     mView.showAverageSpeed(formatSpeed(averageSpeed));
                     if (Constants.SHOW_DEBUG_INFO) {
                         mView.showDebugInfo(averageSpeed, distance, timeElapsed);

--- a/app/src/main/java/com/bgauthey/speedotracker/speedtracking/feedback/FeedbackPresenter.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/speedtracking/feedback/FeedbackPresenter.java
@@ -1,7 +1,7 @@
 package com.bgauthey.speedotracker.speedtracking.feedback;
 
 import com.bgauthey.speedotracker.Constants;
-import com.bgauthey.speedotracker.service.LocationService;
+import com.bgauthey.speedotracker.service.LocationProvider;
 
 import java.text.DecimalFormat;
 
@@ -11,19 +11,19 @@ import java.text.DecimalFormat;
 public class FeedbackPresenter implements FeedbackContract.Presenter {
 
     private FeedbackContract.View mView;
-    private LocationService mLocationService;
+    private LocationProvider mLocationProvider;
 
-    public FeedbackPresenter(FeedbackContract.View view, LocationService locationService) {
+    public FeedbackPresenter(FeedbackContract.View view, LocationProvider locationProvider) {
         mView = view;
-        mLocationService = locationService;
+        mLocationProvider = locationProvider;
     }
 
     void registerListener() {
-        mLocationService.registerOnLocationServiceAverageSpeedChangedListener(mAverageSpeedChangedListener);
+        mLocationProvider.registerOnLocationServiceAverageSpeedChangedListener(mAverageSpeedChangedListener);
     }
 
     void unregisterListener() {
-        mLocationService.unregisterOnLocationServiceAverageSpeedChangedListener(mAverageSpeedChangedListener);
+        mLocationProvider.unregisterOnLocationServiceAverageSpeedChangedListener(mAverageSpeedChangedListener);
     }
 
     static String formatSpeed(float speed) {
@@ -37,7 +37,7 @@ public class FeedbackPresenter implements FeedbackContract.Presenter {
     @Override
     public void start() {
         registerListener();
-        float averageSpeed = mLocationService.getAverageSpeedHistory();
+        float averageSpeed = mLocationProvider.getAverageSpeedHistory();
         mView.showAverageSpeed(formatSpeed(averageSpeed));
     }
 
@@ -50,8 +50,8 @@ public class FeedbackPresenter implements FeedbackContract.Presenter {
     // Final implementation
     ///////////////////////////////////////////////////////////////////////////
 
-    private final LocationService.OnLocationServiceAverageSpeedChangedListener mAverageSpeedChangedListener =
-            new LocationService.OnLocationServiceAverageSpeedChangedListener() {
+    private final LocationProvider.OnLocationServiceAverageSpeedChangedListener mAverageSpeedChangedListener =
+            new LocationProvider.OnLocationServiceAverageSpeedChangedListener() {
                 @Override
                 public void onLocationServiceAverageSpeedChangedListener(float averageSpeed, float distance, int timeElapsed) {
                     mView.showAverageSpeed(formatSpeed(averageSpeed));

--- a/app/src/main/java/com/bgauthey/speedotracker/speedtracking/instantspeed/InstantSpeedPresenter.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/speedtracking/instantspeed/InstantSpeedPresenter.java
@@ -34,9 +34,9 @@ public class InstantSpeedPresenter implements InstantSpeedContract.Presenter {
     // Final implementations
     ///////////////////////////////////////////////////////////////////////////
 
-    private final LocationProvider.OnLocationServiceSpeedChangedListener mSpeedChangedListener = new LocationProvider.OnLocationServiceSpeedChangedListener() {
+    private final LocationProvider.OnSpeedChangedListener mSpeedChangedListener = new LocationProvider.OnSpeedChangedListener() {
         @Override
-        public void onLocationServiceSpeedChangedListener(float speed, Location location) {
+        public void onSpeedChanged(float speed, Location location) {
             mView.showSpeed(new DecimalFormat("#").format(speed));
             if (Constants.SHOW_DEBUG_INFO) {
                 mView.showLocationDebug(location);
@@ -44,7 +44,7 @@ public class InstantSpeedPresenter implements InstantSpeedContract.Presenter {
         }
 
         @Override
-        public void onLocationServiceSpeedActivityChangedListener(boolean active) {
+        public void onSpeedActivityChanged(boolean active) {
             // Nothing to do
         }
     };

--- a/app/src/main/java/com/bgauthey/speedotracker/speedtracking/instantspeed/InstantSpeedPresenter.java
+++ b/app/src/main/java/com/bgauthey/speedotracker/speedtracking/instantspeed/InstantSpeedPresenter.java
@@ -3,38 +3,38 @@ package com.bgauthey.speedotracker.speedtracking.instantspeed;
 import android.location.Location;
 
 import com.bgauthey.speedotracker.Constants;
-import com.bgauthey.speedotracker.service.LocationService;
+import com.bgauthey.speedotracker.service.LocationProvider;
 
 import java.text.DecimalFormat;
 
 /**
- * Listens to {@link LocationService} updates and updates the UI as required.
+ * Listens to {@link LocationProvider} updates and updates the UI as required.
  */
 public class InstantSpeedPresenter implements InstantSpeedContract.Presenter {
 
     private InstantSpeedContract.View mView;
-    private LocationService mLocationService;
+    private LocationProvider mLocationProvider;
 
-    public InstantSpeedPresenter(InstantSpeedContract.View view, LocationService locationService) {
+    public InstantSpeedPresenter(InstantSpeedContract.View view, LocationProvider locationProvider) {
         mView = view;
-        mLocationService = locationService;
+        mLocationProvider = locationProvider;
     }
 
     @Override
     public void start() {
-        mLocationService.registerOnLocationServiceSpeedChangedListener(mSpeedChangedListener);
+        mLocationProvider.registerOnLocationServiceSpeedChangedListener(mSpeedChangedListener);
     }
 
     @Override
     public void stop() {
-        mLocationService.unregisterOnLocationServiceSpeedChangedListener(mSpeedChangedListener);
+        mLocationProvider.unregisterOnLocationServiceSpeedChangedListener(mSpeedChangedListener);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // Final implementations
     ///////////////////////////////////////////////////////////////////////////
 
-    private final LocationService.OnLocationServiceSpeedChangedListener mSpeedChangedListener = new LocationService.OnLocationServiceSpeedChangedListener() {
+    private final LocationProvider.OnLocationServiceSpeedChangedListener mSpeedChangedListener = new LocationProvider.OnLocationServiceSpeedChangedListener() {
         @Override
         public void onLocationServiceSpeedChangedListener(float speed, Location location) {
             mView.showSpeed(new DecimalFormat("#").format(speed));

--- a/app/src/mock/java/com/bgauthey/speedotracker/Injection.java
+++ b/app/src/mock/java/com/bgauthey/speedotracker/Injection.java
@@ -4,14 +4,15 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import com.bgauthey.speedotracker.service.FakeLocationService;
-import com.bgauthey.speedotracker.service.LocationService;
+import com.bgauthey.speedotracker.service.LocationProvider;
+
 
 /**
- * Enables injection of mock implementations for {@link LocationService}
+ * Enables injection of mock implementations for {@link LocationProvider}
  */
 public class Injection {
 
-    public static LocationService provideLocationProvider(@NonNull Context context) {
+    public static LocationProvider provideLocationProvider(@NonNull Context context) {
         return FakeLocationService.getInstance();
     }
 }

--- a/app/src/mock/java/com/bgauthey/speedotracker/service/FakeLocationService.java
+++ b/app/src/mock/java/com/bgauthey/speedotracker/service/FakeLocationService.java
@@ -6,10 +6,10 @@ import android.os.Handler;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * A fake {@link LocationService} that generates a new speed every second using a {@link Handler}
+ * A fake {@link LocationProvider} that generates a new speed every second using a {@link Handler}
  * when tracking is started.
  */
-public class FakeLocationService extends LocationService {
+public class FakeLocationService extends LocationProvider {
 
     private static final long INTERVAL_TIME = 1000L;
     private static final float[] FAKE_SPEEDS = {8, 12, 28, 45, 60, 72, 90, 120, 70, 60, 20, 12, 0, 0};

--- a/app/src/prod/java/com/bgauthey/speedotracker/Injection.java
+++ b/app/src/prod/java/com/bgauthey/speedotracker/Injection.java
@@ -3,17 +3,17 @@ package com.bgauthey.speedotracker;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.bgauthey.speedotracker.service.LocationService;
+import com.bgauthey.speedotracker.service.LocationProvider;
 import com.bgauthey.speedotracker.service.gps.DefaultGpsLocationCallback;
 import com.bgauthey.speedotracker.service.gps.GpsLocationCallback;
 import com.bgauthey.speedotracker.service.gps.GpsLocationProvider;
 
 /**
- * Enables injection of production implementations for {@link LocationService}
+ * Enables injection of production implementations for {@link LocationProvider}
  */
 public class Injection {
 
-    public static LocationService provideLocationProvider(@NonNull Context context) {
+    public static LocationProvider provideLocationProvider(@NonNull Context context) {
         return GpsLocationProvider.getInstance(provideLocationCallback(context));
     }
 

--- a/app/src/test/java/com/bgauthey/speedotracker/service/LocationProviderForTest.java
+++ b/app/src/test/java/com/bgauthey/speedotracker/service/LocationProviderForTest.java
@@ -1,9 +1,9 @@
 package com.bgauthey.speedotracker.service;
 
 /**
- * A {@link LocationService} for unit tests. Easy way to trigger events.
+ * A {@link LocationProvider} for unit tests. Easy way to trigger events.
  */
-public class LocationProviderForTest extends LocationService {
+public class LocationProviderForTest extends LocationProvider {
 
     private boolean mTrackingReady = false;
     private boolean mTrackingRunning = false;


### PR DESCRIPTION
## Context
Some classes are not correctly named regarding the README.md

## Changes
* Renaming `LocationService` class to `LocationProvider`
* Renaming listeners' interfaces within `LocationProvider` to be a bit less verbose
  - `OnLocationServiceStateChangedListener` → `OnSpeedRecordingStateChangedListener`
  - `OnLocationServiceSpeedChangedListener` → `OnSpeedChangedListener`
  - `OnLocationServiceAverageSpeedChangedListener` → `OnAverageSpeedChangedListener`